### PR TITLE
Some proposed fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.9.0",
+    "cross-env": "^1.0.8",
     "eslint": "^2.11.0",
     "eslint-plugin-node": "^1.4.0",
     "mocha": "^2.5.3",
     "npm-run-all": "^2.1.1",
     "nyc": "^6.4.4",
     "power-assert": "^1.4.1",
+    "shx": "^0.1.2",
     "sinon": "^1.17.4"
   },
   "files": [
@@ -43,9 +45,9 @@
   },
   "scripts": {
     "build": "npm-run-all build:*",
-    "build:to5": "BABEL_ENV=production babel --out-dir=lib src",
-    "clean": "rm -rf lib coverage .nyc_output npm-debug.log",
-    "cover": "BABEL_ENV=coverage nyc --reporter text --reporter html mocha --require babel-register",
+    "build:to5": "cross-env BABEL_ENV=production babel --out-dir=lib src",
+    "clean": "shx rm -rf lib coverage .nyc_output npm-debug.log",
+    "cover": "cross-env BABEL_ENV=coverage nyc --reporter text --reporter html mocha --require babel-register",
     "lint": "eslint src test",
     "mocha": "mocha",
     "postversion": "git push && git push --tags && npm run clean",

--- a/src/MIDIAccess.js
+++ b/src/MIDIAccess.js
@@ -27,11 +27,11 @@ class MIDIAccess extends events.EventEmitter {
   }
 
   get inputs() {
-    return new Map(this.$api.outputs.map(port => [ port.name, new MIDIInput(this, port.target) ]));
+    return new Map(this.$api.outputs.map(port => [ port.id, new MIDIInput(this, port.target) ]));
   }
 
   get outputs() {
-    return new Map(this.$api.inputs.map(port => [ port.name, new MIDIOutput(this, port.target) ]));
+    return new Map(this.$api.inputs.map(port => [ port.id, new MIDIOutput(this, port.target) ]));
   }
 
   get onstatechange() {

--- a/src/MIDIAccess.js
+++ b/src/MIDIAccess.js
@@ -24,6 +24,7 @@ class MIDIAccess extends events.EventEmitter {
         this._onstatechange.call(this, e);
       }
     });
+    this.$api.on("statechange", e => this.emit("statechange", e));
   }
 
   get inputs() {

--- a/src/MIDIInput.js
+++ b/src/MIDIInput.js
@@ -25,7 +25,7 @@ class MIDIInput extends MIDIPort {
     if (callback === null || typeof callback === "function") {
       this._onmidimessage = callback;
       if (callback && this.connection !== "open") {
-        this.open();
+        this._implicitOpen();
       }
     }
   }

--- a/src/MIDIOutput.js
+++ b/src/MIDIOutput.js
@@ -16,6 +16,8 @@ class MIDIOutput extends MIDIPort {
     if ((data[0] & 0xf0) === 0xf0 && !this.$access.sysexEnabled) {
       throw new Error("System exclusive message is not allowed");
     }
+    if (this.connection !== "open")
+      this._implicitOpen();
     if (this.connection === "open") {
       this.$port.send(data, timestamp);
     }

--- a/src/MIDIPort.js
+++ b/src/MIDIPort.js
@@ -96,31 +96,12 @@ class MIDIPort extends events.EventEmitter {
 
   open() {
     return new Promise((resolve, reject) => {
-      if (this.connection === "open" || this.connection === "pending") {
-        return resolve(this);
-      }
-
-      if (this.state === "disconnected") {
-        this._connection = "pending";
-
-        const event = { port: this };
-
-        this.$access.emit("statechange", event);
-        this.emit("statechange", event);
-
-        return resolve(this);
-      }
-
-      return this._open().then(() => {
-        this._connection = "open";
-
-        const event = { port: this };
-
-        this.$access.emit("statechange", event);
-        this.emit("statechange", event);
-
+      try {
+        this._implicitOpen();
         resolve(this);
-      }, reject);
+      } catch(e) {
+        reject(e);
+      }
     });
   }
 
@@ -148,6 +129,30 @@ class MIDIPort extends events.EventEmitter {
   }
   _close() {
     return Promise.resolve(this);
+  }
+  
+  _implicitOpen() {
+      if (this.connection === "open" || this.connection === "pending") {
+        return;
+      }
+
+      if (this.state === "disconnected") {
+        this._connection = "pending";
+
+        const event = { port: this };
+
+        this.$access.emit("statechange", event);
+        this.emit("statechange", event);
+
+        return;
+      }
+
+      this._connection = "open";
+
+      const event = { port: this };
+
+      this.$access.emit("statechange", event);
+      this.emit("statechange", event);
   }
 }
 

--- a/src/WebMIDITestAPI.js
+++ b/src/WebMIDITestAPI.js
@@ -33,6 +33,8 @@ class WebMIDITestAPI extends events.EventEmitter {
     const device = new MIDIDevice(opts);
 
     this._devices.push(device);
+    
+    this.emit('statechange');
 
     return device;
   }

--- a/test/MIDIInput.js
+++ b/test/MIDIInput.js
@@ -6,12 +6,13 @@ const MIDIAccess = require("../src/MIDIAccess");
 const MIDIPort = require("../src/MIDIPort");
 const MIDIInput = require("../src/MIDIInput");
 const MIDIDevice = require("../src/MIDIDevice");
+const events = require('events');
 
 describe("MIDIInput", () => {
   let access, port;
 
   beforeEach(() => {
-    access = new MIDIAccess({});
+    access = new MIDIAccess(new events.EventEmitter());
     port = new MIDIDevice.MessagePort({}, "input");
   });
 

--- a/test/MIDIOutput.js
+++ b/test/MIDIOutput.js
@@ -5,12 +5,13 @@ const MIDIAccess = require("../src/MIDIAccess");
 const MIDIPort = require("../src/MIDIPort");
 const MIDIOutput = require("../src/MIDIOutput");
 const MIDIDevice = require("../src/MIDIDevice");
+const events = require('events');
 
 describe("MIDIOutput", () => {
   let access, port;
 
   beforeEach(() => {
-    access = new MIDIAccess({});
+    access = new MIDIAccess(new events.EventEmitter());
     port = new MIDIDevice.MessagePort({}, "output");
   });
 
@@ -49,7 +50,7 @@ describe("MIDIOutput", () => {
       }, Error);
     });
     it("sysex: true", () => {
-      const access = new MIDIAccess({}, { sysex: true });
+      const access = new MIDIAccess(new events.EventEmitter(), { sysex: true });
       const output = new MIDIOutput(access, port);
 
       assert.doesNotThrow(() => {

--- a/test/MIDIPort.js
+++ b/test/MIDIPort.js
@@ -5,12 +5,13 @@ const sinon = require("sinon");
 const MIDIAccess = require("../src/MIDIAccess");
 const MIDIPort = require("../src/MIDIPort");
 const MIDIDevice = require("../src/MIDIDevice");
+const events = require('events');
 
 describe("MIDIPort", () => {
   let access, device, port;
 
   beforeEach(() => {
-    access = new MIDIAccess({});
+    access = new MIDIAccess(new events.EventEmitter());
     device = new MIDIDevice();
     port = device.inputs[0];
   });

--- a/test/usecase.js
+++ b/test/usecase.js
@@ -68,7 +68,8 @@ describe("usecase", () => {
 
       return output.send([ 0x90, 0x00, 0x00 ]);
     }).then(() => {
-      assert(device.inputs[0].onmidimessage.callCount === 0);
+      assert(output.connection === "open");
+      assert(device.inputs[0].onmidimessage.callCount === 1);
     });
   });
 });


### PR DESCRIPTION
- Perform implicit sync open() on first use of port (`onmidimessage` assignment / `send()` call)
- Emit `statechange` event when creating a device
- Key `inputs` and `outputs` on device `id` rather than name
